### PR TITLE
Grendahl adding explore shares

### DIFF
--- a/Host Monitor.ahk
+++ b/Host Monitor.ahk
@@ -36,10 +36,6 @@ FileInstall, inc\defaultSettings.xml, inc\settings.xml, 0
 FileInstall, inc\transform.xslt, inc\transform.xslt, 1
 FileInstall, hosts.txt, hosts.txt, 0
 
-;Clean up file blocking
-Loop, %A_WorkingDir%\*.*, 0, 1 ;Loop all files from A_WorkingDir and subdirectories
-    FileDelete, fileName:Zone.Identifier$DATA ;Remove Zone Identifier Data to Unblock file
-
 ;<=====  Startup  =============================================================>
 ;Receive messages from slave scripts and Windows
 OnMessage(0x4a, "Receive_WM_COPYDATA")

--- a/Host Monitor.ahk
+++ b/Host Monitor.ahk
@@ -124,7 +124,7 @@ Menu, ContextMenu, Add, Ping Graph, ContextMenuHandler
 Menu, ContextMenu, Add
 Menu, ContextMenu, Add, RDP, ContextMenuHandler
 Menu, ContextMenu, Add
-Menu, ContextMenu, Add, Explore C:, ContextMenuHandler
+Menu, ContextMenu, Add, Explore Shares, ContextMenuHandler
 Menu, ContextMenu, Add
 Menu, ContextMenu, Add, Browse, ContextMenuHandler
 Menu, ContextMenu, Add, Browse (https), ContextMenuHandler
@@ -199,7 +199,7 @@ Loop % hosts.MaxIndex() {
 
     if hosts[A_Index, "alias"] {
         Gui, Add, Text, % "xp+5 yp+5 w140 h15 gDummyLabel +0x200 +BackgroundTrans vt"
-            . A_Index . " +Center", % subStr(hosts[A_Index, "alias"], 1, 25)
+            . A_Index . " +Center" , % subStr(hosts[A_Index, "alias"], 1, 25)
     }
     else {
         Gui, Add, Text, % "xp+5 yp+5 w140 h15 gDummyLabel +0x200 +BackgroundTrans vt"
@@ -277,12 +277,15 @@ ContextMenuHandler:
         StartPingGraph(host)
     else if (A_ThisMenuItem == "RDP")
         Run, % "mstsc /v:" . host
-    else if (A_ThisMenuItem == "Explore C:")
-        Run, % "explore \\" . host . "\c$"
+    else if (A_ThisMenuItem == "Explore Shares") {
+        hostName := IPHelper.ReverseLookup(host)
+        StringSplit, hostName, hostName,.
+        Run, % A_ScriptDir "\inc\Shares.ahk " . hostName1
+    }
     else if (A_ThisMenuItem == "Browse")
-        Run, % "http://" . host
+        Run, % "http://" . hosts[reply[1], "name"], % subStr(hosts[reply[1], "name"], 1, 25)
     else if (A_ThisMenuItem == "Browse (https)")
-        Run, % "https://" . host
+        Run, % "https://" . hosts[reply[1], "name"], % subStr(hosts[reply[1], "name"], 1, 25)
     else if (A_ThisMenuItem == "SSH")
         StartPutty(host, "ssh")
     else if (A_ThisMenuItem == "Telnet")
@@ -631,7 +634,7 @@ Receive_WM_COPYDATA(wParam, lParam){
         else
         {
             ;GuiControl,, % hosts[reply[1], "bgImageID"], % "HBITMAP:*" hGreen
-            GuiControl, +cGreen, % hosts[reply[1], "bgImageID"],
+            GuiControl, +cLime, % hosts[reply[1], "bgImageID"],
         }
 
         ;Refresh host text
@@ -797,3 +800,5 @@ WM_MOUSEMOVE() {
 ;<=====  Includes  ============================================================>
 #Include %A_ScriptDir%\inc
 #Include Common Functions.ahk
+#Include IPHelper.ahk
+

--- a/Host Monitor.ahk
+++ b/Host Monitor.ahk
@@ -158,6 +158,9 @@ if settings.selectSingleNode("/hostMonitor/settings/autoTraceRt").text
 Menu, SettingsMenu, Add, Remember &Window Pos, SettingsMenuHandler
 if settings.selectSingleNode("/hostMonitor/settings/rememberPos").text
     Menu, SettingsMenu, Check, Remember &Window Pos
+Menu, SettingsMenu, Add, Pass &Credentials to Shares, SettingsMenuHandler
+if settings.selectSingleNode("/hostMonitor/settings/useCreds").text
+    Menu, SettingsMenu, Check, Pass &Credentials to Shares
 Menu, SettingsMenu, Add
 Menu, SettingsMenu, Add, Change GUI &Rows, SettingsMenuHandler
 Menu, SettingsMenu, Add, Change Max &Threads, SettingsMenuHandler
@@ -375,6 +378,11 @@ SettingsMenuHandler:
     else if (A_ThisMenuItem == "Remember &Window Pos"){
         Menu, SettingsMenu, ToggleCheck, Remember &Window Pos
         node := settings.selectSingleNode("/hostMonitor/settings/rememberPos")
+        node.text := !node.text
+    }
+    else if (A_ThisMenuItem == "Pass &Credentials to Shares"){
+        Menu, SettingsMenu, ToggleCheck, Pass &Credentials to Shares
+        node := settings.selectSingleNode("/hostMonitor/settings/useCreds")
         node.text := !node.text
     }
     else if (A_ThisMenuItem == "Change GUI &Rows"){

--- a/Host Monitor.ahk
+++ b/Host Monitor.ahk
@@ -36,6 +36,10 @@ FileInstall, inc\defaultSettings.xml, inc\settings.xml, 0
 FileInstall, inc\transform.xslt, inc\transform.xslt, 1
 FileInstall, hosts.txt, hosts.txt, 0
 
+;Clean up file blocking
+Loop, %A_WorkingDir%\*.*, 0, 1 ;Loop all files from A_WorkingDir and subdirectories
+    FileDelete, fileName:Zone.Identifier$DATA ;Remove Zone Identifier Data to Unblock file
+
 ;<=====  Startup  =============================================================>
 ;Receive messages from slave scripts and Windows
 OnMessage(0x4a, "Receive_WM_COPYDATA")

--- a/inc/Shares.ahk
+++ b/inc/Shares.ahk
@@ -31,9 +31,10 @@ If(!Host) {
 
 StringUpper, Host, Host
 
-;Read userName and userPass from settings.xml
+;Read settings.xml
 encryptedUser := settings.selectSingleNode("/hostMonitor/settings/userName").text
 encryptedPass := settings.selectSingleNode("/hostMonitor/settings/userPass").text
+useCreds := settings.selectSingleNode("/hostMonitor/settings/useCreds").text
 
 ;If there userName or userPass settings don't exist, go make some
 If(!encryptedUser || !encryptedPass)
@@ -75,17 +76,19 @@ Explore:
 	Share := " \\" . Host . "\" . Share
 	Gui, Destroy
 	Run, explorer %Share%
-	Loop 20
-	{
-		Sleep 500
-		IfWinExist, Windows Security
+	If(useCreds=1) {
+		Loop 20
 		{
-			WinActivate, Windows Security
-			WinWaitActive, Windows Security
 			Sleep 500
-			Send, %User%{TAB}%Pass%{ENTER}
-			Break
-		}	
+			IfWinExist, Windows Security
+			{
+				WinActivate, Windows Security
+				WinWaitActive, Windows Security
+				Sleep 500
+				Send, %User%{TAB}%Pass%{ENTER}
+				Break
+			}	
+		}
 	}
 ExitApp
 

--- a/inc/Shares.ahk
+++ b/inc/Shares.ahk
@@ -108,7 +108,7 @@ SaveCreds:
         node.text := Pass
         SaveSettings(settings, tdoc)	
 	notEncrypted = 0
-	Run, Shares.ahk %Host%
+	Run, % A_ScriptFullPath . " " . Host
 ExitApp
 
 GuiClose:

--- a/inc/Shares.ahk
+++ b/inc/Shares.ahk
@@ -1,0 +1,185 @@
+/*
+    Shares.ahk
+    Author: Grendahl
+
+    This script takes  host name, host login name, and host password as
+    parameters and provides the user with a list of shares on the host. 
+	The user can then select a share and open it using the passed in credentials.
+*/
+;<=====  System Settings  =====================================================>
+#SingleInstance Off
+#NoEnv
+#NoTrayIcon
+SendMode Input
+
+;<=====  Startup  ==========================================================>
+;Set Encryption seed
+Seed = C0mpl3xPas5word!
+
+;Read in settings.xml and transform.xslt
+settings := loadXML(A_ScriptDir . "\settings.xml")
+tdoc := loadXML(A_ScriptDir . "\transform.xslt")
+
+;Set host to passed in parameter
+Host = %1%
+;Ensure Host is actually passed in
+If(!Host) {
+	Msgbox Invalid Input - Must pass Host as command line parameter
+	ExitApp
+}
+;********NEED TO CONVERT IP BACK TO NAME HERE! (or pass the name and not the IP from the context menu handler)********
+
+StringUpper, Host, Host
+
+;Read userName and userPass from settings.xml
+encryptedUser := settings.selectSingleNode("/hostMonitor/settings/userName").text
+encryptedPass := settings.selectSingleNode("/hostMonitor/settings/userPass").text
+
+;If there userName or userPass settings don't exist, go make some
+If(!encryptedUser || !encryptedPass)
+	gosub SaveCreds
+
+;If User/Pass are not encrypted, send user to set them.
+If encryptedUser is not integer
+	notEncrypted = 1
+If encryptedPass is not integer
+	notEncrypted = 1
+if(notEncrypted == 1)
+	gosub SaveCreds
+
+;If User/Pass are encrypted, decrypt them for use in this script.
+If encryptedUser is integer
+	User := Uncode(settings.selectSingleNode("/hostMonitor/settings/userName").text,Seed)
+If encryptedPass is integer
+	Pass := Uncode(settings.selectSingleNode("/hostMonitor/settings/userPass").text,Seed)
+
+;Enumerate shares on host
+Drives := ListShares(Host, User, Pass)
+
+;<=====  GUI  ==============================================================>
+Menu, Tray, Icon, % A_ScriptDir . "\..\img\Host Monitor.ico"
+Gui, Add, Text,,Choose a share:
+Gui, Add, ListBox, vShareSelection gListBox r%Count%, % Drives
+Gui, Add, Button,  gSaveCreds, Credentials
+Gui, Add, Button, xp+75 yp gExplore  +default, Explore
+Gui, +OwnDialogs +ToolWindow
+Gui, Show, ,%Host%
+return
+
+;<=====  Labels  ==============================================================>
+ListBox:
+	if A_GuiEvent <> DoubleClick
+		return
+Explore:
+	GuiControlGet, Share,,ListBox1
+	Share := " \\" . Host . "\" . Share
+	Gui, Destroy
+	Run, explorer %Share%
+	Loop 20
+	{
+		Sleep 500
+		IfWinExist, Windows Security
+		{
+			WinActivate, Windows Security
+			WinWaitActive, Windows Security
+			Sleep 500
+			Send, %User%{TAB}%Pass%{ENTER}
+			Break
+		}	
+	}
+ExitApp
+
+SaveCreds:
+	Gui, Destroy
+	InputBox, User, Password, Enter username to encrypt:
+	User := Code(User,Seed)
+	InputBox, Pass, Password, Enter password to encrypt:, Hide
+	Pass := Code(Pass,Seed)
+	node := settings.selectSingleNode("/hostMonitor/settings/userName")
+        node.text := User
+        SaveSettings(settings, tdoc)
+	node := settings.selectSingleNode("/hostMonitor/settings/userPass")
+        node.text := Pass
+        SaveSettings(settings, tdoc)	
+	notEncrypted = 0
+	Run, Shares.ahk %Host%
+ExitApp
+
+GuiClose:
+    ExitApp
+
+ESC::ExitApp
+
+;<=====  Functions  ==============================================================>
+ListShares(Server, User, Pass) { ;Enumerate shares on a remote host
+	Global Count = 0
+	PropertyList := "Name"
+	wmiLocator := ComObjCreate("WbemScripting.SWbemLocator")
+	try
+		objWMIService := wmiLocator.ConnectServer(Server, "root\cimv2", User, Pass)
+	catch e
+	{	
+		MsgBox % "Unable to connect to " Server "`,`n" User " does not have permission.`n`n" e.Extra " Error Message:`n"  e.Message
+		ExitApp
+	}
+	WQLQuery = Select * From Win32_Share
+	colDiskDrive := objWMIService.ExecQuery(WQLQuery)._NewEnum
+	While colDiskDrive[objDiskDrive] 
+		Loop, Parse, PropertyList, `,
+		{	
+			Count ++
+			Shares  .= A_index = 1 ? objDiskDrive[A_LoopField] . "|"  :  . A_LoopField
+		}
+	StringTrimRight, Shares, Shares, 1
+	Return, Shares
+}
+
+Code(String, Seed) { ;Encrypt a string using Mersenne Twister
+	Random,, Seed
+	Loop, Parse, String
+	{
+		Random x, 1, 1000000
+		Random y, 1, 1000000
+		newString .= (Asc(A_loopfield)+x) y
+	}
+	return newString
+}
+
+Uncode(String, Seed) { ;Decrept a Mersenne Twister encrypted string
+	Random,, Seed
+	while StrLen(String)>0
+	{
+		Random x, 1, 1000000
+		Random y, 1, 1000000
+		Pos := InStr(String, y)
+		oldString .= Chr(SubStr(String, 1, Pos-1)-x)
+		String := SubStr(String, Pos+StrLen(y))
+	}	
+	return oldString
+}
+
+LoadXML(file){
+    xmlFile := fileOpen(file, "r")
+    xml := xmlFile.read()
+    xmlFile.Close()
+    doc := ComObjCreate("MSXML2.DOMdocument.6.0")
+    doc.async := false
+    if !doc.loadXML(xml)
+    {
+        MsgBox, % "Could not load" . file . "!"
+    }
+    return doc
+}
+
+SaveSettings(settings, tdoc){
+    try {
+        resultDoc := ComObjCreate("MSXML2.DOMdocument.6.0")
+        settings.transformNodeToObject(tdoc, resultDoc)
+        resultDoc.save(A_ScriptDir . "\settings.xml")
+        ObjRelease(Object(resultDoc))
+    } catch e {
+        MsgBox, % "Could not save settings.`n" . e . "`n" . e.description
+        return 0
+    }
+    return 1
+}

--- a/inc/Shares.ahk
+++ b/inc/Shares.ahk
@@ -85,7 +85,10 @@ Explore:
 				WinActivate, Windows Security
 				WinWaitActive, Windows Security
 				Sleep 500
-				Send, %User%{TAB}%Pass%{ENTER}
+				SendRaw %User%
+				Send {TAB}
+				SendRaw %Pass%
+				Send {ENTER}
 				Break
 			}	
 		}

--- a/inc/defaultSettings.xml
+++ b/inc/defaultSettings.xml
@@ -12,7 +12,8 @@
         <winY>10</winY>
         <warnLatency>60</warnLatency>
         <hostPath></hostPath>
-		<userName></userName>
-		<userPass></userPass>
+	<useCreds>0</useCreds>
+	<userName></userName>
+	<userPass></userPass>
     </settings>
 </hostMonitor>

--- a/inc/defaultSettings.xml
+++ b/inc/defaultSettings.xml
@@ -12,7 +12,7 @@
         <winY>10</winY>
         <warnLatency>60</warnLatency>
         <hostPath></hostPath>
-	<useCreds>0</useCreds>
+	<useCreds>1</useCreds>
 	<userName></userName>
 	<userPass></userPass>
     </settings>

--- a/inc/defaultSettings.xml
+++ b/inc/defaultSettings.xml
@@ -12,5 +12,7 @@
         <winY>10</winY>
         <warnLatency>60</warnLatency>
         <hostPath></hostPath>
+		<userName></userName>
+		<userPass></userPass>
     </settings>
 </hostMonitor>

--- a/inc/settings.xml
+++ b/inc/settings.xml
@@ -12,7 +12,7 @@
 		<winY>10</winY>
 		<warnLatency>50</warnLatency>
 		<hostPath></hostPath>
-		<useCreds>0</useCreds>
+		<useCreds>1</useCreds>
 		<userName></userName>
 		<userPass></userPass>
 	</settings>

--- a/inc/settings.xml
+++ b/inc/settings.xml
@@ -6,11 +6,13 @@
 		<checkInterval>60</checkInterval>
 		<pingAvgCount>10</pingAvgCount>
 		<autoTraceRt>0</autoTraceRt>
-		<logging>1</logging>
+		<logging>0</logging>
 		<rememberPos>1</rememberPos>
 		<winX>10</winX>
 		<winY>10</winY>
-		<warnLatency>30</warnLatency>
+		<warnLatency>50</warnLatency>
 		<hostPath></hostPath>
+		<userName></userName>
+		<userPass></userPass>
 	</settings>
 </hostMonitor>

--- a/inc/settings.xml
+++ b/inc/settings.xml
@@ -12,6 +12,7 @@
 		<winY>10</winY>
 		<warnLatency>50</warnLatency>
 		<hostPath></hostPath>
+		<useCreds>0</useCreds>
 		<userName></userName>
 		<userPass></userPass>
 	</settings>


### PR DESCRIPTION
Shares.ahk -
Credentials pass properly to Windows Security prompt
Host Monitor.ahk -
Settings menu modified to turn on/off passing of credentials to Windows Security prompt
Included IPHelper.ahk for reverse host lookup
Added file blocking removal for systems with data protection enabled
Default Settings.xml and Settings.xml -
Three new values required for shares.ahk